### PR TITLE
fix: add missing '@ngrx/schematics' to extensions

### DIFF
--- a/server/src/api/read-extensions.ts
+++ b/server/src/api/read-extensions.ts
@@ -31,6 +31,10 @@ export function availableExtensions() {
       name: '@nativescript/schematics',
       description: 'NativeScript Support'
     },
+    {
+      name: '@ngrx/schematics',
+      description: 'NgRx state management generators'
+    },
     { name: '@ngrx/effects', description: 'NgRx side effect management' },
     {
       name: '@ngrx/store',


### PR DESCRIPTION
@ngrx/schematics appears to be the actual package for NgRx
@ngrx/effects + @ngrx/store didn't actually add schematics to the list despite being installed